### PR TITLE
fix(): fixes https://github.com/pwa-builder/PWABuilder/issues/2626

### DIFF
--- a/src/views/icons-view.ts
+++ b/src/views/icons-view.ts
@@ -233,7 +233,7 @@ export class IconGenerationPanel {
 
     .toolTip {
       visibility: hidden;
-      width: 200px;
+      width: 160px;
       background-color: #f8f8f8;
       color: black;
       text-align: center;
@@ -242,7 +242,7 @@ export class IconGenerationPanel {
       /* Position the tooltip */
       position: absolute;
       top: 0px;
-      right: 65%;
+      left: 70%;
       z-index: 1;
     }
 

--- a/src/views/manifest-view.ts
+++ b/src/views/manifest-view.ts
@@ -490,7 +490,8 @@ export class ManiGenerationPanel {
     
         .toolTip {
           visibility: hidden;
-          width: 200px;
+          width: 160px;
+          left: 70%;
           background-color: #f8f8f8;
           color: black;
           text-align: center;

--- a/src/views/manifest-view.ts
+++ b/src/views/manifest-view.ts
@@ -491,7 +491,6 @@ export class ManiGenerationPanel {
         .toolTip {
           visibility: hidden;
           width: 160px;
-          left: 70%;
           background-color: #f8f8f8;
           color: black;
           text-align: center;
@@ -500,7 +499,7 @@ export class ManiGenerationPanel {
           /* Position the tooltip */
           position: absolute;
           top: 0px;
-          right: 65%;
+          left: 70%;
           z-index: 1;
         }
     


### PR DESCRIPTION
This PR:

- Aligns the tooltips to the right instead of the left (which also makes more sense visually)
- Makes the tooltips a little less wide so they never render off to the right of the screen

I want to revisit the tooltips when I go after this issue https://github.com/pwa-builder/PWABuilder/issues/2629