### PR TITLE
fix(): fixes https://github.com/pwa-builder/PWABuilder/issues/2424

### DIFF
--- a/snippets/pwa-windows.js.code-snippets
+++ b/snippets/pwa-windows.js.code-snippets
@@ -90,7 +90,7 @@
             "// When your app is launched by the OS after a file was opened, you can use the launchQueue object to access the file content.",
             "if ('launchQueue' in window) {",
             "\tconsole.log('File Handling API is supported!');",
-            "\tlaunchQueue.setConsumer(launchParams => {",
+            "\twindow.launchQueue.setConsumer(launchParams => {",
             "\t\thandleFiles(launchParams.files);",
             "\t});",
             "} else {",
@@ -102,7 +102,7 @@
             "\t\tconst blob = await file.getFile();",
             "\t\tblob.handle = file;",
             "\t\tconst text = await blob.text();",
-            "\t\tconsole.log(`${file.name} handled, content: ${text}`);",
+            "\t\tconsole.log(file.name + ' ' + text);",
             "\t}",
             "}"
         ],


### PR DESCRIPTION
This PR:

- Removes usage of template literals as VSCode was breaking on that syntax
- Improves the snippet that was causing the problem slightly by adding `window.launchQueue` instead of just `launchQueue`