### PR TITLE
Small improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "Snippets"
   ],
   "activationEvents": [
+    "onStartupFinished",
     "onCommand:pwa-studio.helloWorld",
     "onCommand:pwa-studio.newPwaStarter",
     "onCommand:pwa-studio.serviceWorker",

--- a/src/manifest-utils.ts
+++ b/src/manifest-utils.ts
@@ -19,7 +19,7 @@ export const maniTests = [
         type: "image/png",
         purpose: "maskable",
       },
-    ]),
+    ], null, 2),
     docsLink: "https://developer.mozilla.org/en-US/docs/Web/Manifest/icons",
     errorString: "icons should be an array with a length > 0",
     quickFix: true,
@@ -216,7 +216,7 @@ export const maniTests = [
         "url": "/?startLive",
         "icons": [{ "src": "https://pwabuilder.com/assets/icons/icon_192.png", "sizes": "192x192" }]
       }
-    ]),
+    ], null, 2),
     docsLink: "https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts",
     errorString:
       "shortcuts should be an array with a length > 0 and should not include webp images",

--- a/src/services/validation/validation.ts
+++ b/src/services/validation/validation.ts
@@ -100,11 +100,8 @@ function createDiagnostic(
   // if globalManifestProblem === true, we dont need to find a range, we just want to return a diagnostic
   if (globalManifestProblem === true) {
     const diagnostic = new vscode.Diagnostic(
-      // range for the last line of the document
-      new vscode.Range(
-        new vscode.Position(doc.lineCount - 1, 0),
-        new vscode.Position(doc.lineCount, 0)
-      ),
+      // range for the first line of the document
+      new vscode.Range(0, 0, 0, 0),
       `Your Web Manifest is missing the ${testString} field`,
       severity
     );


### PR DESCRIPTION
Fixes up some things that I noticed watching Nikola use the extension yesterday:

- Both validations and snippets now get added to the top of the manifest, not the bottom
- Snippets (not the main manifest snippet yet), such as icons and shortcuts are now better formatted
- The extension is now activated without the user having to click on the PWABuilder Icon